### PR TITLE
Fix syntax errors.

### DIFF
--- a/utils/genoffset
+++ b/utils/genoffset
@@ -153,7 +153,7 @@ sub parse_bit {
 			}
 
 			# ビット位置を探す
-			$val_bit = do search_bit($val);
+			$val_bit = search_bit($val);
 
 			# バイト単位に換算する
 			if ($endian eq "B") {
@@ -244,10 +244,10 @@ while ($line = <INFILE>) {
 	chomp $line;
 
 	if ($line =~ /^[ \t]*OFFSET_DEF/) {
-		do parse_offset();
+		parse_offset();
 	}
 	elsif ($line =~ /^[ \t]*_?BIT_REF/) {
-		do ref_bit();
+		ref_bit();
 	}
 }
 seek(INFILE, 0, SEEK_SET);
@@ -255,7 +255,7 @@ while ($line = <INFILE>) {
 	chomp $line;
 
 	if ($line =~ /^[ \t]*_?BIT_([BL])([BHW])/) {
-		do parse_bit($1, $2);
+		parse_bit($1, $2);
 	}
 }
 close(INFILE);

--- a/utils/genrename
+++ b/utils/genrename
@@ -112,7 +112,7 @@ foreach $sym (@syms) {
 		print FILE " */\n";
 	}
 	elsif ($sym ne "") {
-		do generate_define($sym, "");
+		generate_define($sym, "");
 	}
 	else {
 		print FILE "\n";
@@ -132,7 +132,7 @@ foreach $sym (@syms) {
 		print FILE " */\n";
 	}
 	elsif ($sym ne "") {
-		do generate_define($sym, "_");
+		generate_define($sym, "_");
 	}
 	else {
 		print FILE "\n";
@@ -166,7 +166,7 @@ foreach $sym (@syms) {
 		print FILE " */\n";
 	}
 	elsif ($sym ne "") {
-		do generate_undef($sym, "");
+		generate_undef($sym, "");
 	}
 	else {
 		print FILE "\n";
@@ -186,7 +186,7 @@ foreach $sym (@syms) {
 		print FILE " */\n";
 	}
 	elsif ($sym ne "") {
-		do generate_undef($sym, "_");
+		generate_undef($sym, "_");
 	}
 	else {
 		print FILE "\n";

--- a/utils/h8-renesas/genoffset
+++ b/utils/h8-renesas/genoffset
@@ -197,10 +197,10 @@ while ($line = <INFILE>) {
 	chomp $line;
 	
 	if ($line =~ /^_OFFSET_DEF_([^ \t]+):/) {
-		do parse_offset($1);
+		parse_offset($1);
 	}
 	elsif ($line =~ /^_BIT_FIELD_OFFSET_([^ \t]+):/) {
-		do parse_bit($1);
+		parse_bit($1);
 	}
 }
 

--- a/utils/h8-renesas/genvector.pl
+++ b/utils/h8-renesas/genvector.pl
@@ -86,7 +86,7 @@ ERRMESSAGE
 #
 #  オプションの処理
 #
-do Getopt("s");
+Getopt("s");
 
 if ($opt_s == 0) {
 	print STDERR "genvector.pl:\n";

--- a/utils/h8/genvector.pl
+++ b/utils/h8/genvector.pl
@@ -94,7 +94,7 @@ ERRMESSAGE
 #
 #  オプションの処理
 #
-do Getopt("s");
+Getopt("s");
 
 if ($opt_s == 0) {
 	print STDERR "genvector.pl:\n";

--- a/utils/hew-renesas/genoffset
+++ b/utils/hew-renesas/genoffset
@@ -197,10 +197,10 @@ while ($line = <INFILE>) {
 	chomp $line;
 	
 	if ($line =~ /^_OFFSET_DEF_([^ \t]+):/) {
-		do parse_offset($1);
+		parse_offset($1);
 	}
 	elsif ($line =~ /^_BIT_FIELD_OFFSET_([^ \t]+):/) {
-		do parse_bit($1);
+		parse_bit($1);
 	}
 }
 

--- a/utils/hew-renesas/genvector.pl
+++ b/utils/hew-renesas/genvector.pl
@@ -86,7 +86,7 @@ ERRMESSAGE
 #
 #  オプションの処理
 #
-do Getopt("s");
+Getopt("s");
 
 if ($opt_s == 0) {
 	print STDERR "genvector.pl:\n";

--- a/utils/makedep
+++ b/utils/makedep
@@ -58,7 +58,7 @@ use Getopt::Std;
 #
 #  オプションの処理
 #
-do getopt("COTDR");
+getopt("COTDR");
 
 $cc_path = $opt_C;
 $cc_opts = $opt_O;
@@ -160,6 +160,6 @@ sub makedepend_one {
 #
 foreach $file (@ARGV) {
 	%dependlist = ();
-	do makedepend_one($file);
-	do output_dependlist($file) if (%dependlist);
+	makedepend_one($file);
+	output_dependlist($file) if (%dependlist);
 }

--- a/utils/rename
+++ b/utils/rename
@@ -107,5 +107,5 @@ foreach $infile (@ARGV) {
 	# ファイルでなければスキップ
 	next unless (-f $infile);
 
-	do rename($infile) if ($infile ne $deffile);
+	rename($infile) if ($infile ne $deffile);
 }


### PR DESCRIPTION
Newer versions of Perl can't accept the old syntax (`do` at subroutine calls).